### PR TITLE
Add support for github and increase make speed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,11 +51,10 @@ RUN \
         libgudev-dev \
         gstreamer0.10-dev \
         && \
-    # Download sources.        
+    # Download sources.
     chmod 755 /download.sh && \
     /download.sh && \
     # Compile.
-
     cd HandBrake* && \
     ls | echo && \
     ./configure --prefix=/usr \
@@ -64,7 +63,7 @@ RUN \
                 --enable-fdk-aac \
                 && \
     cd build && \
-    make && make install && \
+    make -j$(nproc) && make install && \
     cd .. && \
     # Cleanup.
     del-pkg build-dependencies && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,9 @@
 # Pull base image.
 FROM jlesage/baseimage-gui:alpine-3.6-v3.3.2
 
-# Define software versions.
+# Define software versions. version numbers and github are both options
 ARG HANDBRAKE_VERSION=1.0.7
-
-# Define software download URLs.
-ARG HANDBRAKE_URL=https://download.handbrake.fr/releases/${HANDBRAKE_VERSION}/HandBrake-${HANDBRAKE_VERSION}.tar.bz2
+COPY download.sh /download.sh
 
 # Define working directory.
 WORKDIR /tmp
@@ -19,6 +17,7 @@ WORKDIR /tmp
 # Compile HandBrake
 RUN \
     add-pkg --virtual build-dependencies \
+        git \
         curl \
         build-base \
         yasm \
@@ -52,10 +51,13 @@ RUN \
         libgudev-dev \
         gstreamer0.10-dev \
         && \
-    # Download sources.
-    curl -# -L ${HANDBRAKE_URL} | tar xj && \
+    # Download sources.        
+    chmod 755 /download.sh && \
+    /download.sh && \
     # Compile.
-    cd HandBrake-${HANDBRAKE_VERSION} && \
+
+    cd HandBrake* && \
+    ls | echo && \
     ./configure --prefix=/usr \
                 --disable-gtk-update-checks \
                 --enable-x265 \

--- a/download.sh
+++ b/download.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+if [ "$HANDBRAKE_VERSION" = "github" ]; then
+  git clone https://github.com/HandBrake/HandBrake.git;
+else
+  curl -# -L https://download.handbrake.fr/releases/${HANDBRAKE_VERSION}/HandBrake-${HANDBRAKE_VERSION}.tar.bz2 | tar xj;
+fi


### PR DESCRIPTION
Added a download script that will clone the github repo if the version github is chosen, if not then it will function like normal and download the version number specified by the variable similar to how it currently works. Added a -j$(nproc) flag to the make function so it can be parallelized based on the number of threads that are on the machine. 