### PR TITLE
Update autovideoconverter to process files in upload order

### DIFF
--- a/rootfs/etc/services.d/autovideoconverter/run
+++ b/rootfs/etc/services.d/autovideoconverter/run
@@ -303,7 +303,9 @@ process_watch_folder() {
     WATCHDIR_HASH_update "$WF"
     log "Processing watch folder '$WF'..."
     FILELIST="$(mktemp)"
-    find "$WF" -follow -type f -not -path '*/\.*' | \
+    find "$WF" -follow -type f -not -path '*/\.*' -printf "%T@ %p\n" | \
+        sort -n | \
+        cut -d' ' -f2- | \
         sed 's|/VIDEO_TS/.*$|/VIDEO_TS|g' | \
         sed 's|/BDMV/.*$|/BDMV|g' | \
         uniq > "$FILELIST"


### PR DESCRIPTION
Simply prints the timestamp, use it to sort the files and discard it.

Allow files to be processed in the order they were uploaded - which might not be the case with the current command as it is based on what the filesystem feeds `find`.