### PR TITLE
Fixed typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ with the HandBrake GUI.
 **NOTE**: The status and progression of conversions performed by the automatic
 video converter can only be seen in the container's log.  It is not something
 visible from the GUI.  Container's log can be obtained by executing the command
-`docker log handbrake`, where `handbrake` is the name of the container.  Also,
+`docker logs handbrake`, where `handbrake` is the name of the container.  Also,
 full details about the conversion are stored in `/config/log/hb/conversion.log`
 (container path).
 


### PR DESCRIPTION
Just fixed the missing s. 

`docker log` gives not found 