### PR TITLE
Feature to filter watch folders by files extensions (#143)

### DIFF
--- a/rootfs/etc/services.d/autovideoconverter/run
+++ b/rootfs/etc/services.d/autovideoconverter/run
@@ -320,7 +320,7 @@ process_video() {
 }
 
 process_watch_folder() {
-    local filter
+    local filter='-true'
     WF="$1"
 
     NUM_PROCESSED_FILES=0
@@ -339,13 +339,13 @@ process_watch_folder() {
     log "Processing watch folder '$WF'..."
     FILELIST="$(mktemp)"
 
-    if [ ! -z "${AUTOMATED_CONVERSION_INPUT_FORMAT}" ]; then
+    if [ ! -z "${AUTOMATED_CONVERSION_INPUT_FORMAT:-}" ]; then
         declare -a _types_=(${AUTOMATED_CONVERSION_INPUT_FORMAT})
         filter="${_types_[@]/#/ -o -name *.}"
         filter="${filter# -o }"
     fi
 
-    find "$WF" -follow -type f -not -path '*/\.*' \( $filter \) -printf "%T@ %p\n" | \
+    find "$WF" -follow -type f -not -path '*/\.*' \( ${filter} \) -printf "%T@ %p\n" | \
         sort -n | \
         cut -d' ' -f2- | \
         sed 's|/VIDEO_TS/.*$|/VIDEO_TS|g' | \

--- a/rootfs/etc/services.d/autovideoconverter/run
+++ b/rootfs/etc/services.d/autovideoconverter/run
@@ -340,6 +340,7 @@ process_watch_folder() {
     FILELIST="$(mktemp)"
 
     if [ ! -z "${AUTOMATED_CONVERSION_INPUT_FORMAT}" ]; then
+        local -n _types_ = (${AUTOMATED_CONVERSION_INPUT_FORMAT})
         filter="${_types_[@]/#/ -o -name *.}"
         filter="${filter# -o }"
     fi

--- a/rootfs/etc/services.d/autovideoconverter/run
+++ b/rootfs/etc/services.d/autovideoconverter/run
@@ -340,7 +340,7 @@ process_watch_folder() {
     FILELIST="$(mktemp)"
 
     if [ ! -z "${AUTOMATED_CONVERSION_INPUT_FORMAT}" ]; then
-        local -n _types_ = (${AUTOMATED_CONVERSION_INPUT_FORMAT})
+        declare -a _types_=(${AUTOMATED_CONVERSION_INPUT_FORMAT})
         filter="${_types_[@]/#/ -o -name *.}"
         filter="${filter# -o }"
     fi

--- a/rootfs/etc/services.d/autovideoconverter/run
+++ b/rootfs/etc/services.d/autovideoconverter/run
@@ -320,6 +320,7 @@ process_video() {
 }
 
 process_watch_folder() {
+    local filter
     WF="$1"
 
     NUM_PROCESSED_FILES=0
@@ -337,12 +338,19 @@ process_watch_folder() {
     WATCHDIR_HASH_update "$WF"
     log "Processing watch folder '$WF'..."
     FILELIST="$(mktemp)"
-    find "$WF" -follow -type f -not -path '*/\.*' -printf "%T@ %p\n" | \
+
+    if [ ! -z "${AUTOMATED_CONVERSION_INPUT_FORMAT}" ]; then
+        filter="${_types_[@]/#/ -o -name *.}"
+        filter="${filter# -o }"
+    fi
+
+    find "$WF" -follow -type f -not -path '*/\.*' \( $filter \) -printf "%T@ %p\n" | \
         sort -n | \
         cut -d' ' -f2- | \
         sed 's|/VIDEO_TS/.*$|/VIDEO_TS|g' | \
         sed 's|/BDMV/.*$|/BDMV|g' | \
         uniq > "$FILELIST"
+
     while read -u 3 FILE
     do
         process_video "$FILE" "$WF"


### PR DESCRIPTION
Hello,

This feature creates a new environment variable named $AUTOMATED_CONVERSION_INPUT_FORMAT, which takes extensions separated by a space. If this variable is set, only files with an extension listed in that variable will be processed. 

For instance, setting ```AUTOMATED_CONVERSION_INPUT_FORMAT=wmv divx mov``` would only convert files with wmv, divx or mov extensions without touching (or even listing other files).

This allows fast processing of cluttered /watch folders (because the script doesn't go through every file in the folder) and allow the user to only convert files with some extensions.