### PR TITLE
Adds env variable to make Handbrake figure out the main title.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ of this parameter has the format `<VARIABLE_NAME>=<VALUE>`.
 |`AUTOMATED_CONVERSION_OVERWRITE_OUTPUT`| Setting this to `1` allows the final destination file to be overwritten if it already exists. | `0` |
 |`AUTOMATED_CONVERSION_SOURCE_STABLE_TIME`| Time (in seconds) during which properties (e.g. size, time, etc) of a video file in the watch folder need to remain the same.  This is to avoid processing a file that is being copied. | `5` |
 |`AUTOMATED_CONVERSION_SOURCE_MIN_DURATION`| Minimum title duration (in seconds).  Shorter titles will be ignored.  This applies only to video disc sources (ISO file, `VIDEO_TS` folder or `BDMV` folder). | `10` |
+|`AUTOMATED_CONVERSION_MAIN_FEATURE`| Setting this to `1` uses Handbrakes main-feature detection to try to guess the main feature. | `0` |
 |`AUTOMATED_CONVERSION_CHECK_INTERVAL`| Interval (in seconds) at which the automatic video converter checks for new files. | `5` |
 |`AUTOMATED_CONVERSION_MAX_WATCH_FOLDERS`| Maximum number of watch folders handled by the automatic video converter. | `5` |
 |`HANDBRAKE_DEBUG`| Setting this to `1` enables HandBrake debug logging for both the GUI and the automatic video converter.  For the latter, the increased verbosity is reflected in `/config/log/hb/conversion.log` (container path).  For the GUI, log messages are sent to `/config/log/hb/handbrake.debug.log` (container path).  **NOTE**: When enabled, a lot of information is generated and the log file will grow quickly.  Make sure to enable this temporarily and only when needed. | (unset) |

--- a/rootfs/etc/services.d/autovideoconverter/run
+++ b/rootfs/etc/services.d/autovideoconverter/run
@@ -106,10 +106,17 @@ get_video_hash() {
 
 get_video_titles() {
     video="$1"
-    $HANDBRAKE_CLI -i "$video" \
-                   -t0 \
-                   --min-duration $AC_SOURCE_MIN_DURATION 2>&1 |
-    grep "^+ title " | sed 's/^+ title \([0-9]\+\):$/\1/'
+    if [ "$AC_MAIN_FEATURE" == "0" ];then
+        $HANDBRAKE_CLI -i "$video" \
+                       -t0 \
+                       --main-feature 2>&1 |
+        grep "^+ title " | sed 's/^+ title \([0-9]\+\):$/\1/'
+    else
+        $HANDBRAKE_CLI -i "$video" \
+                       -t0 \
+                       --min-duration $AC_SOURCE_MIN_DURATION 2>&1 |
+        grep "^+ title " | sed 's/^+ title \([0-9]\+\):$/\1/'
+    fi
     return ${PIPESTATUS[0]}
 }
 
@@ -414,6 +421,7 @@ while true; do
         AC_FORMAT="${AUTOMATED_CONVERSION_FORMAT:-mp4}"
         AC_SOURCE_STABLE_TIME="${AUTOMATED_CONVERSION_SOURCE_STABLE_TIME:-5}"
         AC_SOURCE_MIN_DURATION="${AUTOMATED_CONVERSION_SOURCE_MIN_DURATION:-10}"
+        AC_MAIN_FEATURE="${AUTOMATED_CONVERSION_MAIN_FEATURE:-0}"
         AC_OUTPUT_DIR="${AUTOMATED_CONVERSION_OUTPUT_DIR:-/output}"
         AC_OUTPUT_SUBDIR="${AUTOMATED_CONVERSION_OUTPUT_SUBDIR:-UNSET}"
         AC_KEEP_SOURCE="${AUTOMATED_CONVERSION_KEEP_SOURCE:-1}"


### PR DESCRIPTION
Pretty simply adds an environment variable to allow Handbrake to select the main title.

I'm not a fan of the command repetition, but don't recall how to conditionally pass args to a function in a shell script.