### PR TITLE
Detect Intel QuickSync on virtuallized hosts. 

### DIFF
--- a/rootfs/etc/cont-init.d/95-check-qsv.sh
+++ b/rootfs/etc/cont-init.d/95-check-qsv.sh
@@ -13,8 +13,8 @@ PROCESSOR_NAME="$(cat /proc/cpuinfo | grep "model name" | head -n1 | cut -d':' -
 
 log "Processor: $PROCESSOR_NAME"
 
-if ! echo "$PROCESSOR_NAME" | grep -qiw "INTEL"; then
-    log "Intel Quick Sync Video not supported: not an Intel processor."
+if ! echo "$PROCESSOR_NAME" | grep -qiE "(INTEL|KVM|QEMU)"; then
+    log "Intel Quick Sync Video not supported: not a supported processor."
     exit 0
 fi
 
@@ -28,7 +28,7 @@ if [ ! -e "$DRI_DEV" ]; then
     exit 0
 fi
 
-if ! lspci -s "00:02.0" -k | grep -q -w i915; then
+if ! lspci -k | grep -qw i915; then
     log "Intel Quick Sync Video not supported: video adapter not using i915 driver."
     exit 0
 fi


### PR DESCRIPTION
When the Docker host is a virtual machine, the CPU model name is not always Intel and the integrated graphics are passed through at a different PCI address. 

/proc/cpuinfo:

```
processor       : 0
vendor_id       : GenuineIntel
cpu family      : 15
model           : 6
model name      : Common KVM processor
stepping        : 1
microcode       : 0x1
cpu MHz         : 2208.000
cache size      : 16384 KB
physical id     : 0
siblings        : 2
core id         : 0
cpu cores       : 2
apicid          : 0
initial apicid  : 0
fpu             : yes
fpu_exception   : yes
cpuid level     : 13
wp              : yes
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx lm constant_tsc nopl xtopology cpuid tsc_known_freq pni cx16 x2apic hypervisor lahf_lm cpuid_fault pti
bugs            : cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs itlb_multihit mmio_unknown
bogomips        : 4416.00
clflush size    : 64
cache_alignment : 128
address sizes   : 40 bits physical, 48 bits virtual

```

lspci:

```
00:10.0 VGA compatible controller: Intel Corporation UHD Graphics 630 (Desktop)
        Subsystem: Dell UHD Graphics 630 (Desktop)
        Kernel driver in use: i915
        Kernel modules: i915
```
