### PR TITLE
possible fix for Issue #261 ?

### DIFF
--- a/rootfs/etc/services.d/autovideoconverter/run
+++ b/rootfs/etc/services.d/autovideoconverter/run
@@ -17,6 +17,11 @@ if [ "${HANDBRAKE_DEBUG:-0}" -eq 1 ]; then
     HANDBRAKE_CLI="$HANDBRAKE_CLI --verbose=3"
 fi
 
+# make AUTO_CROP an environment variable so this can be enforced for auto video converter
+if [ "${AUTO_CROP:-0}" -eq 1 ]; then
+    HANDBRAKE_CLI="$HANDBRAKE_CLI --crop=0:0:0:0"
+fi
+
 WATCHDIR_HASH="$(mktemp -d)"
 
 OUTPUT_DIR_TMP=""


### PR DESCRIPTION
fix for #261 maybe

On the HandbrakeCLI documentation states that:
```
--crop   <top:bottom:left:right>
                          
                           Set picture cropping in pixels
                           (default: automatically remove black bars)
```

basically unless you manually specify to not crop it will crop I test this change on my local machine by adding these new lines and it works

The HandbrakeCLI ignores some of the preset properties that are imported from a `preset.json` file