### PR TITLE
docs: fix link to quick sync video processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,7 +802,7 @@ methods:
     sudo chown root:video /dev/dri/*
     ```
 
-[list]: https://ark.intel.com/Search/FeatureFilter?productType=processors&QuickSyncVideo=true
+[list]: https://ark.intel.com/Search/FeatureFilter?productType=873&0_QuickSyncVideo=True
 [Intel Ark]: https://ark.intel.com
 
 ### unRAID

--- a/appdefs.yml
+++ b/appdefs.yml
@@ -248,7 +248,7 @@ app:
               sudo chown root:video /dev/dri/*
               ```
 
-          [list]: https://ark.intel.com/Search/FeatureFilter?productType=processors&QuickSyncVideo=true
+          [list]: https://ark.intel.com/Search/FeatureFilter?productType=873&0_QuickSyncVideo=True
           [Intel Ark]: https://ark.intel.com
       - title: unRAID
         level: 3


### PR DESCRIPTION
This fixes the search parameters in the link to the Intel Quick Sync Video processors.