### PR TITLE
Remove volume declaration for /trash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -172,7 +172,6 @@ ENV \
 VOLUME ["/storage"]
 VOLUME ["/output"]
 VOLUME ["/watch"]
-VOLUME ["/trash"]
 
 # Metadata.
 LABEL \


### PR DESCRIPTION
I upgraded from a ~2022 image and noticed a new `/trash` [anonymous volume](https://forums.docker.com/t/why-does-this-volumes-section-in-a-service-in-docker-compose-create-a-single-anonymous-volume/133627) was being created every time the container restarted.

It seems this was added in 2754c90 but I'm not totally sure why. My understanding of [`VOLUME` instructions](https://docs.docker.com/reference/dockerfile/#volume) is that they're used to populate a mounted volume with the contents from an image, but `/trash` doesn't appear to contain anything by default.

Combined with the fact that it's an optional feature that's disabled by default, I _think_ this instruction should be removed from the Dockerfile. I don't believe this has any effect on users who are relying on the `/trash` feature and have intentionally mounted a volume at that path. Possibly the other `VOLUME` instructions aren't needed either (at least I don't think so), but I haven't actually looked into that at all.